### PR TITLE
Add numpy-only compute option to fvgp

### DIFF
--- a/fvgp/fvgp.py
+++ b/fvgp/fvgp.py
@@ -11,7 +11,6 @@ import math
 
 import itertools
 import time
-import torch
 from functools import partial
 from fvgp.gp import GP
 
@@ -61,7 +60,7 @@ class fvGP(GP):
         If 'ram economy' is False,the function's input is x1, x2, hyperparameters, and the output is
         a numpy array of shape (len(hyperparameters) x U x V)
     gp_mean_function : Callable, optional
-        A function that evaluates the prior mean at an input position. It accepts as input 
+        A function that evaluates the prior mean at an input position. It accepts as input
         an array of positions (of size V x D), hyperparameters (a 1-D array of length D+1 for the default kernel)
         and a `gpcam.gp_optimizer.GPOptimizer` instance. The return value is a 1-D array of length V. If None is provided,
         `fvgp.gp.GP.default_mean_function` is used.
@@ -162,7 +161,7 @@ class fvGP(GP):
             The values of the data points. Shape (V,output_number).
         value_positions : np.ndarray, optional
             A 3-D numpy array of shape (U x output_number x output_dim), so that for each measurement position, the outputs
-            are clearly defined by their positions in the output space. 
+            are clearly defined by their positions in the output space.
             The default is np.array([[0],[1],[2],[3],...,[output_number - 1]]) for each
             point in the input space. The default is only permissible if output_dim is 1.
         variances : np.ndarray, optional

--- a/fvgp/gp.py
+++ b/fvgp/gp.py
@@ -4,7 +4,7 @@ import time
 import itertools
 from functools import partial
 import math
-import warning
+import warnings
 
 import dask.distributed as distributed
 import matplotlib.pyplot as plt
@@ -17,7 +17,7 @@ try:
     import torch
     DEFAULT_COMPUTE_DEVICE = "cpu"
 except ImportError:
-    warning.warn("The pytorch package is not installed. For improved performance with fvgp and gpCAM, install pytorch.")
+    warnings.warn("The pytorch package is not installed. For improved performance with fvgp and gpCAM, install pytorch.")
     DEFAULT_COMPUTE_DEVICE = "numpy"
 
 from .mcmc import mcmc

--- a/fvgp/gp.py
+++ b/fvgp/gp.py
@@ -4,6 +4,7 @@ import time
 import itertools
 from functools import partial
 import math
+import warning
 
 import dask.distributed as distributed
 import matplotlib.pyplot as plt
@@ -11,7 +12,13 @@ import numpy as np
 from scipy.optimize import differential_evolution
 from scipy.optimize import minimize
 from loguru import logger
-import torch
+
+try:
+    import torch
+    DEFAULT_COMPUTE_DEVICE = "cpu"
+except ImportError:
+    warning.warn("The pytorch package is not installed. For improved performance with fvgp and gpCAM, install pytorch.")
+    DEFAULT_COMPUTE_DEVICE = "numpy"
 
 from .mcmc import mcmc
 from hgdl.hgdl import HGDL
@@ -104,7 +111,7 @@ class GP():
         y_data,
         init_hyperparameters,
         variances = None,
-        compute_device = "cpu",
+        compute_device = DEFAULT_COMPUTE_DEVICE,
         gp_kernel_function = None,
         gp_kernel_function_grad = None,
         gp_mean_function = None,

--- a/fvgp/gp.py
+++ b/fvgp/gp.py
@@ -772,7 +772,7 @@ class GP():
                     logger.error("reason: {}", str(e))
                     self.compute_device = 'numpy'
         if self.compute_device == 'numpy':
-            x, res, rank, s = np.linalg.lstsq(A.numpy(), b.numpy(), rcond=None)
+            x, res, rank, s = np.linalg.lstsq(A, b, rcond=None)
             return x
         elif self.compute_device == "gpu" or A.ndim < 3:
             A = torch.from_numpy(A).cuda()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 wheel
 versioneer
-torch >= 1.9.0
 scipy
 numpy
 matplotlib


### PR DESCRIPTION
In isolated cases with specific python environments, `torch.linalg.solve` produces segmentation faults. This PR adds a numpy-only option to the `GP` that avoids torch.

Specifically, packaging torch into a mac app with pyinstaller results in a torch installation that is only semi-functional. For example, its `slogdet` operates fine, however `solve` produces segfaults. This is likely an issue with pyinstaller's torch hook, however investigation of this issue may be extensive. This PR provides a workaround primarily to support Tsuchinoko builds.